### PR TITLE
Refactoring Promises, push code more to left

### DIFF
--- a/api/models/Passport.js
+++ b/api/models/Passport.js
@@ -9,16 +9,15 @@ const bcrypt = require('bcrypt')
  * @param {Object}   passport
  * @param {Function} next
  */
-const hashPassword = (passport, next) => {
-  if (passport.password) {
-    bcrypt.hash(passport.password, 10, (err, hash) => {
-      passport.password = hash
-      next(err, passport)
-    })
+function hashPassword(passport, next) {
+  if (! passport.password) {
+    return next(null, passport)
   }
-  else {
-    next(null, passport)
-  }
+
+  bcrypt.hash(passport.password, 10, (err, hash) => {
+    passport.password = hash
+    next(err, passport)
+  })
 }
 
 

--- a/api/policies/Passport.js
+++ b/api/policies/Passport.js
@@ -24,15 +24,15 @@ module.exports = class PassportPolicy extends Policy {
     this.init(req, res, () => {
       this.app.services.PassportService.passport.authenticate('jwt', (error, user, info) => {
         if (error) {
-          res.serverError(error)
+          return res.serverError(error)
         }
-        else if (!user) {
-          res.status(403).send(info.message)
+
+        if (! user) {
+          return res.status(403).send(info.message)
         }
-        else {
-          req.user = user
-          next()
-        }
+
+        req.user = user
+        next()
       })(req, res)
     })
   }
@@ -42,19 +42,16 @@ module.exports = class PassportPolicy extends Policy {
       // User is allowed, proceed to the next policy,
       // or if this is the last policy, the controller
       if (req.session && req.session.authenticated) {
-        next()
+        return next()
       }
-      else {
-        // User is not allowed
-        // (default res.forbidden() behavior can be overridden in `config/403.js`)
-        if (req.wantsJSON) {
-          res.status(403).json()
-        }
-        else {
-          res.redirect(this.app.config.session.redirect.logout)
-        }
+
+      // User is not allowed
+      // (default res.forbidden() behavior can be overridden in `config/403.js`)
+      if (req.wantsJSON) {
+        return res.status(403).json()
       }
+
+      res.redirect(this.app.config.session.redirect.logout)
     })
   }
 }
-

--- a/api/services/protocols/local.js
+++ b/api/services/protocols/local.js
@@ -7,7 +7,8 @@ module.exports = (app) => {
     const id = _.get(app, 'config.session.strategies.local.options.usernameField')
     criteria[id || 'username'] = identifier
 
-    app.services.Passport.login(identifier, password).then(user => next(null, user))
-      .catch(error => next(error))
+    app.services.Passport.login(identifier, password)
+    .then(user => next(null, user))
+    .catch(next)
   }
 }

--- a/archetype/config/session.js
+++ b/archetype/config/session.js
@@ -4,7 +4,7 @@ const JwtStrategy = require('passport-jwt').Strategy
 const ExtractJwt = require('passport-jwt').ExtractJwt
 
 const EXPIRES_IN_SECONDS = 60 * 60 * 24
-const SECRET = process.env.tokenSecret || 'mysupersecuretoken'
+const SECRET = process.env.TOKEN_SECRET || 'mysupersecuretoken'
 const ALGORITHM = 'HS256'
 const ISSUER = 'localhost'
 const AUDIENCE = 'localhost'

--- a/config/policies.js
+++ b/config/policies.js
@@ -1,2 +1,1 @@
-
 module.exports = {}

--- a/lib/passports.js
+++ b/lib/passports.js
@@ -71,7 +71,7 @@ module.exports = {
       // have a way of identifying the user in the future. Throw an error and let
       // whoever's next in the line take care of it.
       if (!user.username && !user.email) {
-        return next(new Error('Neither a username nor email was available'));
+        return next(new Error('Neither a username nor email was available'))
       }
 
       app.orm.Passport.findOne({
@@ -84,11 +84,13 @@ module.exports = {
             //           authentication provider.
             // Action:   Create a new user and assign them a passport.
             if (!passport) {
-              app.orm.User.create(user).then(user => {
+              app.orm.User.create(user)
+              .then(user => {
                 query.user = user.id
-                app.orm.Passport.create(query).then(passport => next(null, user))
-                  .catch(err => next(err))
-              }).catch(err => next(err))
+                return app.orm.Passport.create(query)
+              })
+              .then(passport => next(null, user))
+              .catch(next)
             }
             // Scenario: An existing user is trying to log in using an already
             //           connected passport.
@@ -101,10 +103,11 @@ module.exports = {
 
               // Save any updates to the Passport before moving on
               app.orm.Passport.update(passport.id, passport)
-                .then(passport => {
-                  app.orm.User.findOne({id: passport[0].user.id}).then(user => next(null, user))
-                    .catch(err => next(err))
-                }).catch(err => next(err))
+              .then(passport => {
+                return app.orm.User.findOne({id: passport[0].user.id})
+              })
+              .then(user => next(null, user))
+              .catch(next)
             }
           }
           else {
@@ -114,8 +117,9 @@ module.exports = {
             if (!passport) {
               query.user = req.user.id
 
-              app.orm.Passport.create(query).then(passport => next(null, req.user))
-                .catch(err => next(err))
+              app.orm.Passport.create(query)
+              .then(() => next(null, req.user))
+              .catch(next)
             }
             // Scenario: The user is a nutjob or spammed the back-button.
             // Action:   Simply pass along the already established session.
@@ -123,7 +127,8 @@ module.exports = {
               next(null, req.user)
             }
           }
-        }).catch(err => next(err))
+        })
+        .catch(next)
     }
 
     passport.serializeUser((user, next) => {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -6,9 +6,9 @@ module.exports = {
   validatePassportsConfig (config) {
     return new Promise((resolve, reject) => {
       joi.validate(config, schemas.passportsConfig, (err, value) => {
-        if (err) return reject(new TypeError('config.session: ' + err))
-
-        return resolve(value)
+        return err
+          ? reject(new TypeError('config.session: ' + err))
+          : resolve(value)
       })
     })
   }


### PR DESCRIPTION
Tried hard to push the code more to the left by removing `else` and `else if` blocks where possible. Also tweaked how `.catch()` blocks are handled.

Fixed one bug: In the `PassportService.disconnect()` function, I fixed a potential issue where a request to disconnect a non-existent passport would silently pass. Perhaps this was the intended behaviour so please review carefully here. I changed it to throw `E_USER_NO_PASSWORD`.

Changed: In _archetype/config/session.js_, I changed `process.env.tokenSecret` to `process.env.TOKEN_SECRET` as that's usually the format of env vars most commonly used.

There are a couple of coding style tweaks, but if you don't like those let me know and I'll just revert them back, no hard feelings. :)