### PR TITLE
Fixed Sequelize passport password update hook

### DIFF
--- a/api/models/sequelize/Passport.js
+++ b/api/models/sequelize/Passport.js
@@ -15,6 +15,7 @@ module.exports = {
             hashPassword(app.config.passport.bcrypt, values, fn)
           },
           beforeUpdate: (values, options, fn) => {
+            options.validate = false // skip re-validation of password hash
             hashPassword(app.config.passport.bcrypt, values, fn)
           }
         },

--- a/api/services/PassportService.js
+++ b/api/services/PassportService.js
@@ -144,6 +144,39 @@ module.exports = class PassportService extends Service {
   }
 
   /**
+   * Update the local passport password of an user
+   * @param user
+   * @param password
+   * @returns {Promise}
+   */
+  updateLocalPassword(user, password) {
+    const criteria = (user._id) ? {_id: user.id} : {id: user.id} //eslint-disable-line
+
+    return this.app.services.FootprintService.find('user', criteria, {populate: 'passports'})
+      .then(user => {
+        if (user && user.length > 0) {
+          user = user[0]
+          if (user.passports) {
+            const localPassport = user.passports.find(passportObj => passportObj.protocol === 'local')
+            if (localPassport) {
+              localPassport.password = password
+              return localPassport.save()
+            }
+            else {
+              return Promise.resolve()
+            }
+          }
+          else {
+            return Promise.reject('no_available_passports')
+          }
+        }
+        else {
+          return Promise.reject('no_user')
+        }
+      })
+  }
+
+  /**
    * Assign local Passport to user
    *
    * This function can be used to assign a local Passport to a user who doens't

--- a/api/services/PassportService.js
+++ b/api/services/PassportService.js
@@ -163,15 +163,15 @@ module.exports = class PassportService extends Service {
               return localPassport.save()
             }
             else {
-              return Promise.resolve()
+              throw new Error('E_NO_AVAILABLE_LOCAL_PASSPORT')
             }
           }
           else {
-            return Promise.reject('no_available_passports')
+            throw new Error('E_NO_AVAILABLE_PASSPORTS')
           }
         }
         else {
-          return Promise.reject('no_user')
+          throw new Error('E_USER_NOT_FOUND')
         }
       })
   }

--- a/test/integration/services/PassportService.test.js
+++ b/test/integration/services/PassportService.test.js
@@ -5,7 +5,7 @@ const assert = require('assert')
 const supertest = require('supertest')
 
 describe('PassportService', () => {
-  let request, token
+  let request, token, user
   before((done) => {
     request = supertest('http://localhost:3000')
     request
@@ -16,6 +16,7 @@ describe('PassportService', () => {
       .end((err, res) => {
         assert.equal(res.body.redirect, '/')
         assert.notEqual(res.body.user.id,null)
+        user = res.body.user
         token = res.body.token
         done(err)
       })
@@ -106,5 +107,20 @@ describe('PassportService', () => {
         assert.equal(res.text, 'ok')
         done(err)
       })
+  })
+
+  it('should be able to update password', (done) => {
+    // Hackfix for trailpack-mongoose, we should update trailpack-mongoose FootprintService.find for avoiding this
+    const criteria = (user._id) ? {_id: user.id} : {id: user.id} //eslint-disable-line
+
+    global.app.services.FootprintService.find('user', criteria, {populate: 'passports'})
+      .then(user => {
+        global.app.services.PassportService.updateLocalPassword(user[0], 'testtest')
+          .then(() => {
+            done()
+          })
+          .catch(done)
+      })
+      .catch(done)
   })
 })


### PR DESCRIPTION
Updating a local passport fail Sequelize validation cause beforeUpdate hook re-validate models if some keys are changed (see: https://github.com/sequelize/sequelize/issues/4325#issuecomment-131002772 )

I fixed this behavior and added a commodity feature `PassportService.updateLocalPassword(user, newPassword)` for updating user passwords