### PR TITLE
- Removed password length limit from mongoose and sequelize

### DIFF
--- a/api/models/mongoose/Passport.js
+++ b/api/models/mongoose/Passport.js
@@ -28,8 +28,7 @@ module.exports = {
       password: {
         type: String,
         required: true,
-        minlength: 8,
-        maxlength: 30
+        minlength: 8
       },
 
       provider: {

--- a/api/models/sequelize/Passport.js
+++ b/api/models/sequelize/Passport.js
@@ -43,8 +43,8 @@ module.exports = {
         allowNull: true,
         validate: {
           len: {
-            args: [8, 30],
-            msg: 'Password must be between 8 and 30 characters in length'
+            args: [8, null],
+            msg: 'Password must be long at least 8 characters'
           }
         }
       },

--- a/api/models/sequelize/Passport.js
+++ b/api/models/sequelize/Passport.js
@@ -43,7 +43,7 @@ module.exports = {
         allowNull: true,
         validate: {
           len: {
-            args: [8, null],
+            args: [8, undefined],
             msg: 'Password must be long at least 8 characters'
           }
         }

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "login"
   ],
   "dependencies": {
-    "bcryptjs": "^2.4.0",
+    "bcryptjs": "2.4.3",
     "joi": "10.2.2",
-    "jsonwebtoken": "^7.2.1",
+    "jsonwebtoken": "7.3.0",
     "lodash": "^4.17.3",
     "passport": "^0.3.2",
-    "trailpack": "^2.1.0",
+    "trailpack": "2.1.2",
     "trails-controller": "^2.0.0",
     "trails-model": "^2.0.1",
     "trails-policy": "^2.0.0",
@@ -39,8 +39,8 @@
   },
   "devDependencies": {
     "eslint": "3.17.1",
-    "eslint-config-trails": "^2.0.4",
-    "express": "^4.14.0",
+    "eslint-config-trails": "2.0.8",
+    "express": "4.15.2",
     "mocha": "^3.2.0",
     "passport-jwt": "^2.1.0",
     "passport-local": "^1.0.0",
@@ -48,13 +48,13 @@
     "smokesignals": "^2",
     "snyk": "1.25.2",
     "sqlite3": "^3.1.6",
-    "supertest": "^3.0.0",
-    "trailpack-express": "^2.0.0",
+    "supertest": "3.0.0",
+    "trailpack-express": "2.0.3",
     "trailpack-mongoose": "2.1.1",
     "trailpack-router": "^2.1.0",
     "trailpack-sequelize": "^2.0.0",
     "trailpack-waterline": "^2.0.0",
-    "trails": "^2.0.0"
+    "trails": "2.0.2"
   },
   "scripts": {
     "snyk-auth": "snyk auth $SNYK_TOKEN",


### PR DESCRIPTION
Removed max length requirements from mongoose & sequelize models validation (Waterline seems to don't have those limitations)
I personally use a 64 char password, I think that 30 chars aren't enough nowadays 