### PR TITLE
Fix callback URLs

### DIFF
--- a/lib/passports.js
+++ b/lib/passports.js
@@ -175,10 +175,16 @@ module.exports = {
           let callback = strategiesOptions.callback
 
           if (!callback) {
-            callback = 'auth/' + name + '/callback'
+            const prefix = _.get(app.config, 'passport.prefix') || _.get(app.config, 'footprints.prefix')
+            callback = prefix + '/auth/' + name + '/callback'
           }
           const serverProtocol = app.config.web.ssl ? 'https' : 'http'
-          const baseUrl = serverProtocol + '://' + (app.config.web.host || 'localhost') + ':' + app.config.web.port
+          let baseUrl = serverProtocol + '://' + (app.config.web.host || 'localhost')
+          const serverPort = app.config.web.port
+
+          if (serverPort !== 80 && serverPort !== 443) {
+            baseUrl = baseUrl + ':' + serverPort
+          }
 
           switch (protocol) {
             case 'oauth':


### PR DESCRIPTION
The callback url right now is not working because the prefix (defined in config or from footprint) is not being appended to the URL. I also removed the port binding in case of the port be 80 or 443 (as it's an unnecessary declaration).