### PR TITLE
Fix Passport model for Mongoose and authentication for third-party

### DIFF
--- a/api/models/mongoose/Passport.js
+++ b/api/models/mongoose/Passport.js
@@ -23,11 +23,11 @@ module.exports = {
       protocol: {
         type: String,
         match: /^[a-zA-Z0-9]+$/,
-        required: false
+        required: true
       },
       password: {
         type: String,
-        required: true,
+        required: false,
         minlength: 8
       },
 

--- a/lib/passports.js
+++ b/lib/passports.js
@@ -83,7 +83,7 @@ module.exports = {
           // Scenario: A new user is attempting to sign up using a third-party
           //           authentication provider.
           // Action:   Create a new user and assign them a passport.
-          if (passport.length === 0) {
+          if (passport.length == 0) {
             // Merge the profile received from the third-party authentication
             // provider with the user.
             app.config.passport.mergeThirdPartyProfile(user, profile).then(mergedProfile =>
@@ -108,11 +108,11 @@ module.exports = {
 
             // Save any update to the Passport and read the associated user instance
             return Promise.all([
-              app.services.FootprintService.findAssociation('Passport', passport.id, 'User'),
+              app.services.FootprintService.findAssociation('Passport', passport.id, 'user'),
               app.services.FootprintService.update('Passport', passport.id, passport.toJSON())
             ])
               .then(results => {
-                const userInstance = results[0] // Not so usefull, just for keeping namings clear
+                const userInstance = results[0][0] // Not so usefull, just for keeping namings clear
                 next(null, userInstance)
               })
               .catch(next)
@@ -122,11 +122,10 @@ module.exports = {
           // Scenario: A user is currently logged in and trying to connect a new
           //           passport.
           // Action:   Create and assign a new passport to the user.
-          if (passport.length === 0) {
+          if (passport.length == 0) {
             if (query.hasOwnProperty('tokens') && typeof(query.tokens) === 'object') {
               query.tokens = JSON.stringify(query.tokens)
             }
-            query.user = req.user.id
 
             app.services.FootprintService.createAssociation('user', req.user.id, 'passports', query)
               .then(passport => next(null, req.user))

--- a/lib/passports.js
+++ b/lib/passports.js
@@ -126,6 +126,7 @@ module.exports = {
             if (query.hasOwnProperty('tokens') && typeof(query.tokens) === 'object') {
               query.tokens = JSON.stringify(query.tokens)
             }
+            query.user = req.user.id
 
             app.services.FootprintService.createAssociation('user', req.user.id, 'passports', query)
               .then(passport => next(null, req.user))

--- a/lib/passports.js
+++ b/lib/passports.js
@@ -78,72 +78,74 @@ module.exports = {
       app.services.FootprintService.find('passport', {
         provider: provider,
         identifier: query.identifier.toString()
-      }, {findOne: true})
-        .then(passport => {
-          if (!req.user) {
-            // Scenario: A new user is attempting to sign up using a third-party
-            //           authentication provider.
-            // Action:   Create a new user and assign them a passport.
-            if (!passport) {
-              // Merge the profile received from the third-party authentication
-              // provider with the user.
-              app.config.passport.mergeThirdPartyProfile(user, profile).then(mergedProfile =>
-                app.services.FootprintService.create('user', mergedProfile).then(user => {
-                  query.tokens = JSON.stringify(query.tokens)
-                  app.services.FootprintService.createAssociation('user', user.id, 'passports', query)
-                    .then(passport => next(null, user))
-                    .catch(next)
-                }).catch(next)
-              ).catch(next)
-            }
-            // Scenario: An existing user is trying to log in using an already
-            //           connected passport.
-            // Action:   Get the user associated with the passport.
-            else {
-              // If the tokens have changed since the last session, update them
-              if (query.hasOwnProperty('tokens') && query.tokens !== passport.tokens) {
-                passport.tokens = JSON.stringify(query.tokens)
-              }
-
-              // Save any update to the Passport and read the associated user instance
-              return Promise.all([
-                app.services.FootprintService.findAssociation('Passport', passport.id, 'User'),
-                app.services.FootprintService.update('Passport', passport.id, passport.toJSON())
-              ])
-                .then(results => {
-                  const userInstance = results[0] // Not so usefull, just for keeping namings clear
-                  next(null, userInstance)
-                })
-                .catch(next)
-            }
-          }
-          else {
-            // Scenario: A user is currently logged in and trying to connect a new
-            //           passport.
-            // Action:   Create and assign a new passport to the user.
-            if (!passport) {
-              if (query.hasOwnProperty('tokens') && typeof(query.tokens) === 'object') {
+      }).then(passport => {
+        if (!req.user) {
+          // Scenario: A new user is attempting to sign up using a third-party
+          //           authentication provider.
+          // Action:   Create a new user and assign them a passport.
+          if (passport.length === 0) {
+            // Merge the profile received from the third-party authentication
+            // provider with the user.
+            app.config.passport.mergeThirdPartyProfile(user, profile).then(mergedProfile =>
+              app.services.FootprintService.create('user', mergedProfile).then(user => {
                 query.tokens = JSON.stringify(query.tokens)
-              }
-
-              app.services.FootprintService.createAssociation('user', req.user.id, 'passports', query)
-                .then(passport => next(null, req.user))
-                .catch(next)
+                query.user = user.id
+                app.services.FootprintService.createAssociation('user', user.id, 'passports', query)
+                  .then(passport => next(null, user))
+                  .catch(next)
+              }).catch(next)
+            ).catch(next)
+          }
+          // Scenario: An existing user is trying to log in using an already
+          //           connected passport.
+          // Action:   Get the user associated with the passport.
+          else {
+            passport = passport[0]
+            // If the tokens have changed since the last session, update them
+            if (query.hasOwnProperty('tokens') && query.tokens !== passport.tokens) {
+              passport.tokens = JSON.stringify(query.tokens)
             }
-            // Scenario: The user is a nutjob or spammed the back-button.
-            // Action:   Simply pass along the already established session.
+
+            // Save any update to the Passport and read the associated user instance
+            return Promise.all([
+              app.services.FootprintService.findAssociation('Passport', passport.id, 'User'),
+              app.services.FootprintService.update('Passport', passport.id, passport.toJSON())
+            ])
+              .then(results => {
+                const userInstance = results[0] // Not so usefull, just for keeping namings clear
+                next(null, userInstance)
+              })
+              .catch(next)
+          }
+        }
+        else {
+          // Scenario: A user is currently logged in and trying to connect a new
+          //           passport.
+          // Action:   Create and assign a new passport to the user.
+          if (passport.length === 0) {
+            if (query.hasOwnProperty('tokens') && typeof(query.tokens) === 'object') {
+              query.tokens = JSON.stringify(query.tokens)
+            }
+
+            app.services.FootprintService.createAssociation('user', req.user.id, 'passports', query)
+              .then(passport => next(null, req.user))
+              .catch(next)
+          }
+          // Scenario: The user is a nutjob or spammed the back-button.
+          // Action:   Simply pass along the already established session.
+          else {
+            passport = passport[0]
+            // If the user currently logged in is different than the user associated
+            // with the third-party authentication provider, throw an error.
+            if (passport.user != req.user.id) {
+              return next(new Error('Third party account already linked to another user'))
+            }
             else {
-              // If the user currently logged in is different than the user associated
-              // with the third-party authentication provider, throw an error.
-              if (passport.UserId != req.user.id) {
-                return next(new Error('Third party account already linked to another user'))
-              }
-              else {
-                next(null, req.user)
-              }
+              next(null, req.user)
             }
           }
-        }).catch(next)
+        }
+      }).catch(next)
     }
 
     passport.serializeUser((user, next) => {
@@ -182,7 +184,7 @@ module.exports = {
           let baseUrl = serverProtocol + '://' + (app.config.web.host || 'localhost')
           const serverPort = app.config.web.port
 
-          if (serverPort !== 80 && serverPort !== 443) {
+          if (serverPort != 80 && serverPort != 443) {
             baseUrl = baseUrl + ':' + serverPort
           }
 


### PR DESCRIPTION
As I told in my issue, the Mongoose model validation is not the expected, this commit changes it to the expected validation. 
Another issue is that the authentication with third-party was not working in several scenarios, this commit fixes the authentication problems. The callback was trying to use the findOne option in the find, Mongoose and Waterline don't allow that option on FootprintService with a criteria, just with the model ID. Also, manually add the User ID on the Passport model, as trails don't do it (at least with mongoose), failing the whole authentication.

The findAssociation has an issue on trailpack-mongoose, where the Parent Model name is hardcoded as 'User', I already filed a PR for that change, so until we have this change, the Mongoose authentication can fail.